### PR TITLE
Update Fedora 35 images to re-import them

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,12 +81,12 @@ resource "openstack_images_image_v2" "fedora-34-20210427" {
   }
 }
 
-resource "openstack_images_image_v2" "fedora-35-20211102" {
+resource "openstack_images_image_v2" "fedora-35-20211119" {
   for_each = toset(var.architectures)
 
   region           = var.region
 
-  name             = "Fedora 35 (${each.value}) [2021-11-02]"
+  name             = "Fedora 35 (${each.value}) [2021-11-19]"
   visibility       = "public"
   image_source_url = "https://mirrors.kernel.org/fedora/releases/35/Cloud/${each.value}/images/Fedora-Cloud-Base-35-1.2.${each.value}.qcow2"
   image_cache_path = "$HOME/.terraform/${var.region}-image-cache"


### PR DESCRIPTION
My typo fix from 7699186 was the right thing to do, but the old, broken
image remained in the Vexxhost system.

Change the name of the resource as well as the name of the image to
delete the old image and import a new one.

Signed-off-by: Major Hayden <major@redhat.com>